### PR TITLE
Show health status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Other
+.DS_Store
+*.sublime-*

--- a/iati_datastore/docs_source/api/error.rst
+++ b/iati_datastore/docs_source/api/error.rst
@@ -1,6 +1,22 @@
 Data Error API
 ==============
 
+Health status
+-------------
+
+Check the health status of the Datstore.
+
+   `</api/1/about>`_
+
+If the last fetch, last successful fetch, or last parsed date is
+more than 24 hours ago, `ok` will be `false` and `healthy` will
+be `unhealthy`.
+
+If the last fetch, last successful fetch, or last parsed date is
+less than 24 hours ago, `ok` will be `true` and `healthy` will
+be `healthy`.
+
+
 General data
 ------------
 

--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -59,7 +59,7 @@ def about():
         status={True: 'healthy', False: 'unhealthy'}[healthy],
         status_data={
             'last_fetch': max_last_fetch,
-            'last_succ': max_last_succ,
+            'last_successful_fetch': max_last_succ,
             'last_parsed': max_last_parsed
         },
         indexed_activities=count_activity,


### PR DESCRIPTION
Shows the health status of the Datastore on the `/api/1/about` URL, e.g.:
```json
{
  "indexed_activities": 473, 
  "indexed_transactions": 5203, 
  "ok": false, 
  "status": "unhealthy", 
  "status_data": {
    "last_fetch": "Mon, 07 Dec 2020 18:48:22 GMT", 
    "last_parsed": "Mon, 07 Dec 2020 18:48:47 GMT", 
    "last_succ": "Mon, 07 Dec 2020 18:48:22 GMT"
  }
}
```