### PR TITLE
Hierarchy

### DIFF
--- a/iati_datastore/iatilib/frontend/serialize/csv.py
+++ b/iati_datastore/iatilib/frontend/serialize/csv.py
@@ -111,6 +111,7 @@ receiver_org = partial(transaction_org, 'receiver_org')
 title = attrgetter("title")
 description = attrgetter("description")
 iati_identifier = attrgetter("iati_identifier")
+hierarchy = attrgetter("hierarchy")
 
 
 def recipient_country_code(activity):
@@ -228,7 +229,7 @@ def fielddict_from_major_version(major_version):
     class FieldDict(OrderedDict):
         common_field = {
             u"iati-identifier": iati_identifier,
-            u"hierarchy" :  partial(codelist_code, 'hierarchy'),
+            u"hierarchy": hierarchy,
             u"last-updated-datetime": attrgetter(u'last_updated_datetime'),
             u"default-language" : partial(codelist_code, 'default_language'),
             u"reporting-org" : reporting_org_name,

--- a/iati_datastore/iatilib/model.py
+++ b/iati_datastore/iatilib/model.py
@@ -95,7 +95,7 @@ class Participation(db.Model):
 class Activity(db.Model):
     __tablename__ = "activity"
     iati_identifier = sa.Column(sa.Unicode, primary_key=True, nullable=False)
-    hierarchy = sa.Column(codelists.RelatedActivityType.db_type())
+    hierarchy = sa.Column(sa.Integer)
     default_language = sa.Column(codelists.Language.db_type())
     # parsed from xml iati-activity@last-updated-datetime
     last_updated_datetime = sa.Column(sa.DateTime, nullable=True)

--- a/iati_datastore/iatilib/parse.py
+++ b/iati_datastore/iatilib/parse.py
@@ -387,8 +387,8 @@ def related_activities(xml, resource=no_resource, major_version='1'):
 
 def hierarchy(xml, resource=None, major_version='1'):
     xml_value = xval(xml, "@hierarchy", None)
-    if xml_value:
-        return codelists.by_major_version[major_version].RelatedActivityType.from_string(xml_value)
+    if (xml_value) and (xml_value != ''):
+        return int(xml_value)
     return None
 
 

--- a/iati_datastore/iatilib/test/__init__.py
+++ b/iati_datastore/iatilib/test/__init__.py
@@ -81,8 +81,8 @@ def xml_compare(x1, x2, reporter=None):
         if reporter:
             reporter('tail: %r != %r' % (x1.tail, x2.tail))
         return False
-    cl1 = x1.getchildren()
-    cl2 = x2.getchildren()
+    cl1 = list(x1)
+    cl2 = list(x2)
     if len(cl1) != len(cl2):
         if reporter:
             reporter('children length differs, %i != %i'

--- a/iati_datastore/iatilib/test/test_parser.py
+++ b/iati_datastore/iatilib/test/test_parser.py
@@ -288,7 +288,7 @@ class TestParse2xxActivity(AppTestCase):
         self.assertEquals(cl2.TiedStatus.partially_tied, self.act.default_tied_status)
 
     def test_default_hierarchy(self):
-        self.assertEquals(cl2.RelatedActivityType.parent, self.act.hierarchy)
+        self.assertEquals(1, self.act.hierarchy)
 
     def test_default_language(self):
         self.assertEquals(cl2.Language.english, self.act.default_language)
@@ -496,7 +496,7 @@ class TestParseActivity(AppTestCase):
 
     def test_default_hierarchy(self):
         activities = [ a for a in parse.document(fixture_filename("default_currency.xml")) ]
-        self.assertEquals(cl.RelatedActivityType.parent, activities[0].hierarchy)
+        self.assertEquals(1, activities[0].hierarchy)
 
     def test_default_language(self):
         activities = [ a for a in parse.document(fixture_filename("default_currency.xml")) ]

--- a/iati_datastore/iatilib/test/test_serializers/test_csv_activities.py
+++ b/iati_datastore/iatilib/test/test_serializers/test_csv_activities.py
@@ -375,7 +375,7 @@ class TestCSVExample(CSVTstMixin, TestCase):
 
     def test_hierarchy(self):
         data = self.process([fac.ActivityFactory.build(
-            hierarchy=cl.RelatedActivityType.parent
+            hierarchy=1
         )])
         self.assertField({'hierarchy': "1"}, data[0])
 

--- a/iati_datastore/iatilib/test/test_serializers/test_csv_transactions.py
+++ b/iati_datastore/iatilib/test/test_serializers/test_csv_transactions.py
@@ -295,7 +295,7 @@ class TestCSVTransactionExample(TestCase, CSVTstMixin):
 
     def test_hierarchy(self):
         activity = fac.ActivityFactory.build(
-            hierarchy=cl.RelatedActivityType.parent
+            hierarchy=1
         )
         data = self.process([
             fac.TransactionFactory.build(activity=activity)


### PR DESCRIPTION
Fix bug whereby hierarchy was expected to use the RelatedActivity codelist. Now it is expected only to be an integer.

In reality, this probably had no effect on import, as I am not aware of any publisher that uses a hierarchy of > 3, and there are 4 values on the RelatedActivity codelist.

It is possible that some publishers are using values that are not integers and that this could cause parse failures. I think this is OK and should be picked up through the logs.