### PR TITLE
Add a base URL route

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -1,8 +1,9 @@
 from collections import namedtuple
 from datetime import datetime
 import sqlalchemy as sa
-from flask import (request, Response, Blueprint, jsonify, abort,
-                   render_template, make_response)
+from flask import (current_app, request, Response, Blueprint,
+                   jsonify, abort, render_template, make_response,
+                   url_for)
 from flask.views import MethodView
 from werkzeug.datastructures import MultiDict
 from flask_sqlalchemy import Pagination
@@ -14,7 +15,7 @@ from iatilib.model import (Activity, Resource, Transaction, Dataset,
 from . import dsfilter, validators, serialize
 
 
-api = Blueprint('api', __name__)
+api = Blueprint('api1', __name__)
 Scrollination = namedtuple('Scrollination', 'query offset limit total items')
 
 def dictify(resource):
@@ -25,6 +26,21 @@ def dictify(resource):
         else:
             fields.append((key, resource.__dict__[key]))
     return dict(fields)
+
+@api.route('/')
+def list_routes():
+    urls = []
+    rules = [
+        r for r in current_app.url_map.iter_rules()
+        if r.endpoint.startswith('api1.')]
+    for rule in rules:
+        options = {}
+        for arg in rule.arguments:
+            options[arg] = "[{0}]".format(arg)
+        url = url_for(rule.endpoint, _external=True, **options)
+        urls.append(url)
+    urls = sorted(urls)
+    return jsonify(urls)
 
 @api.route('/meta/filters/')
 def meta_filters():

--- a/iati_datastore/iatilib/frontend/routes.py
+++ b/iati_datastore/iatilib/frontend/routes.py
@@ -15,6 +15,10 @@ def homepage():
 def error():
     return redirect(url_for('routes.docs', path='api/error/'))
 
+@routes.route('/api/')
+def api_latest():
+    return redirect(url_for('api1.list_routes'))
+
 @routes.route('/docs/')
 @routes.route('/docs/<path:path>')
 def docs(path=''):

--- a/iati_datastore/iatilib/test/test_api.py
+++ b/iati_datastore/iatilib/test/test_api.py
@@ -18,6 +18,22 @@ class ClientTestCase(AppTestCase):
         self.client = self.app.test_client()
 
 
+class TestLatestApiRedirect(ClientTestCase):
+    def test_latest_api_redirect(self):
+        resp = self.client.get('/api/')
+        self.assertEquals(302, resp.status_code)
+        self.assertRegex(resp.headers['Location'], '/api/1/$')
+
+
+class TestListRoutes(ClientTestCase):
+    def test_list_routes(self):
+        resp = self.client.get('/api/1/')
+        self.assertEquals(200, resp.status_code)
+        self.assertEquals("application/json", resp.content_type)
+        data = json.loads(resp.data)
+        self.assertIn('http://localhost/api/1/', data)
+
+
 class TestAbout(ClientTestCase):
     def test_about_http(self):
         resp = self.client.get('/api/1/about/')


### PR DESCRIPTION
I’d like to easily be able to explore the API, via some sort of listings page. This adds that.

Apparently this is called [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS).