### PR TITLE
Remove `iati create-database`; Add confirmation prompt to `iati drop-database`

### DIFF
--- a/iati_datastore/iatilib/console.py
+++ b/iati_datastore/iatilib/console.py
@@ -6,6 +6,7 @@ import subprocess
 
 import click
 from flask.cli import FlaskGroup, with_appcontext
+import flask_migrate
 import requests
 from sqlalchemy import not_
 
@@ -83,7 +84,7 @@ def parse_file(filenames, verbose=False, fail_xml=False, fail_spec=False):
 @cli.command()
 @with_appcontext
 def create_database():
-    db.create_all()
+    flask_migrate.upgrade()
 
 
 @cli.command()

--- a/iati_datastore/iatilib/console.py
+++ b/iati_datastore/iatilib/console.py
@@ -84,4 +84,6 @@ def parse_file(filenames, verbose=False, fail_xml=False, fail_spec=False):
 @cli.command()
 @with_appcontext
 def drop_database():
+    """Drop all database tables."""
+    click.confirm('Are you sure?', abort=True)
     db.drop_all()

--- a/iati_datastore/iatilib/console.py
+++ b/iati_datastore/iatilib/console.py
@@ -83,11 +83,5 @@ def parse_file(filenames, verbose=False, fail_xml=False, fail_spec=False):
 
 @cli.command()
 @with_appcontext
-def create_database():
-    flask_migrate.upgrade()
-
-
-@cli.command()
-@with_appcontext
 def drop_database():
     db.drop_all()

--- a/iati_datastore/iatilib/test/test_console.py
+++ b/iati_datastore/iatilib/test/test_console.py
@@ -17,7 +17,7 @@ class ConsoleTestCase(AppTestCase):
         self.assertEquals(1, mock.call_count)
         self.assertEquals(mock.call_args.args[0], command.split(' '))
 
-    @mock.patch('iatilib.db.create_all')
+    @mock.patch('flask_migrate.upgrade')
     def test_create_db(self, mock):
         self.runner.invoke(console.create_database)
         self.assertEquals(1, mock.call_count)

--- a/iati_datastore/iatilib/test/test_console.py
+++ b/iati_datastore/iatilib/test/test_console.py
@@ -17,7 +17,9 @@ class ConsoleTestCase(AppTestCase):
         self.assertEquals(1, mock.call_count)
         self.assertEquals(mock.call_args.args[0], command.split(' '))
 
+    @mock.patch('click.confirm')
     @mock.patch('iatilib.db.drop_all')
-    def test_drop_db(self, mock):
+    def test_drop_db(self, prompt_mock, drop_all_mock):
         self.runner.invoke(console.drop_database)
-        self.assertEquals(1, mock.call_count)
+        self.assertEquals(1, prompt_mock.call_count)
+        self.assertEquals(1, drop_all_mock.call_count)

--- a/iati_datastore/iatilib/test/test_console.py
+++ b/iati_datastore/iatilib/test/test_console.py
@@ -17,11 +17,6 @@ class ConsoleTestCase(AppTestCase):
         self.assertEquals(1, mock.call_count)
         self.assertEquals(mock.call_args.args[0], command.split(' '))
 
-    @mock.patch('flask_migrate.upgrade')
-    def test_create_db(self, mock):
-        self.runner.invoke(console.create_database)
-        self.assertEquals(1, mock.call_count)
-
     @mock.patch('iatilib.db.drop_all')
     def test_drop_db(self, mock):
         self.runner.invoke(console.drop_database)


### PR DESCRIPTION
This now creates a migrations table, in the same way that `iati db upgrade` does.

Alternatively, we could scrap this command and just have `iati db upgrade` since it does exactly the same thing.