### PR TITLE
Use hyphens instead of underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sudo -u postgres psql -c "CREATE USER [SYSTEM USER]"
 sudo -u postgres psql -c "GRANT ALL ON DATABASE iati_datastore TO [SYSTEM USER]"
 
 # Start the process of grabbing the source data
-iati crawler download
+iati crawler download-and-update
 
 # Start a development server – this should be run in a seperate terminal window
 iati run
@@ -177,7 +177,7 @@ Deploying with apache
 * Run `iati create_database` to create the db tables
 * Set up a cron job for updates. (Add the following line after running `crontab -e`)
 
-        0 0 * * * export DATABASE_URL='postgres:///iati-datastore'; /usr/local/bin/iati crawler download
+        0 0 * * * export DATABASE_URL='postgres:///iati-datastore'; /usr/local/bin/iati crawler download-and-update
 
 * Run a worker with `iati queue background`
     - This needs to persist when you close your ssh connection. A simple way of doing this is using [screen](https://www.gnu.org/software/screen/).
@@ -202,7 +202,7 @@ Updating activities after changing import code
 
 * Run this SQL query on the database - `UPDATE resource SET last_succ=NULL;`
 * Restart background process
-* Run `iati crawler download` (or wait for cron to run it for you)
+* Run `iati crawler download-and-update` (or wait for cron to run it for you)
 
 
 Generation of Documentation

--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -393,7 +393,7 @@ def download_and_update():
     update_registry()
 
 
-@manager.cli.command('download_and_update')
+@manager.cli.command('download-and-update')
 def download_and_update_cmd():
     """
     Enqueue a download of all IATI data from


### PR DESCRIPTION
After deployment, it’s important to update the `crawl_update.sh` script on the server, to point at the new command.