### PR TITLE
Fix routes listed at /api/1/

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -28,6 +28,7 @@ def list_routes():
         options = {
             arg: arg.upper()
             for arg in rule.arguments
+            if arg not in rule.defaults
         }
         url = url_for(rule.endpoint, _external=True, **options)
         urls.append(url)
@@ -350,7 +351,8 @@ activity_view = ActivityView.as_view('activity')
 api.add_url_rule(
     '/access/activity/',
     defaults={"format": "json"},
-    view_func=activity_view
+    view_func=activity_view,
+    endpoint="activity-view"
 )
 
 api.add_url_rule(


### PR DESCRIPTION
Fixes #176.

This uses https://stackoverflow.com/a/7794516/2323348 to name one of the endpoints so it is distinct. Plus there is a bit of a hack to work around a default args issue (but I don’t think it is too hacky).