### PR TITLE
Get stream=True working for CSV and JSON

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -233,7 +233,7 @@ class Stream(object):
     offset = ''
 
     def __init__(self, query):
-        self.items = query.all()
+        self.items = query
         self.total = query.count()
 
 

--- a/iati_datastore/iatilib/frontend/serialize/jsonserializer.py
+++ b/iati_datastore/iatilib/frontend/serialize/jsonserializer.py
@@ -6,6 +6,7 @@ from flask import current_app
 from flask import json as jsonlib
 
 import xmltodict
+from flask_sqlalchemy import BaseQuery
 
 from iatilib.model import (
     Activity, Organisation, Transaction, Participation, SectorPercentage,
@@ -18,6 +19,8 @@ class JSONEncoder(jsonlib.JSONEncoder):
     TWOPLACES = Decimal(10) ** -2
 
     def default(self, o):
+        if isinstance(o, BaseQuery):
+            return o.all()
         if isinstance(o, datetime.date):
             return o.strftime("%Y-%m-%d")
         if isinstance(o, codelists.enum.EnumSymbol):

--- a/iati_datastore/iatilib/frontend/serialize/jsonserializer.py
+++ b/iati_datastore/iatilib/frontend/serialize/jsonserializer.py
@@ -31,16 +31,8 @@ class JSONEncoder(jsonlib.JSONEncoder):
         return super().default(o)
 
 
-class DatastoreJSONEncoder(jsonlib.JSONEncoder):
-    TWOPLACES = Decimal(10) ** -2
-
+class DatastoreJSONEncoder(JSONEncoder):
     def default(self, o):
-        if isinstance(o, datetime.date):
-            return o.strftime("%Y-%m-%d")
-        if isinstance(o, codelists.enum.EnumSymbol):
-            return o.value
-        if isinstance(o, Decimal):
-            return str(o.quantize(self.TWOPLACES))
         if isinstance(o, Activity):
             return json_rep(o)
         return super().default(o)


### PR DESCRIPTION
This reverts IATI#317, because it broke CSV streaming.

I don’t think it’s broken on http://datastore.iatistandard.org, because I don’t think IATI#317 was ever deployed.

This PR addresses IATI#315 a slightly different way instead.

Fixes #175.