### PR TITLE
Add XML and JSON options to query builder

### DIFF
--- a/iati_datastore/query_builder_source/pages/index.vue
+++ b/iati_datastore/query_builder_source/pages/index.vue
@@ -611,6 +611,15 @@ export default {
       handler: function(newFilters) {
         this.updateParams()
       }
+    },
+    format: {
+      handler: function(newFormat) {
+        if (newFormat == 'xml') {
+          this.grouping = ''
+          this.breakdown = 'activity'
+        }
+        this.updateParams()
+      }
     }
   },
   mounted() {

--- a/iati_datastore/query_builder_source/pages/index.vue
+++ b/iati_datastore/query_builder_source/pages/index.vue
@@ -614,7 +614,7 @@ export default {
     },
     format: {
       handler: function(newFormat) {
-        if (newFormat == 'xml') {
+        if (newFormat != 'csv') {
           this.grouping = ''
           this.breakdown = 'activity'
         }

--- a/iati_datastore/query_builder_source/pages/index.vue
+++ b/iati_datastore/query_builder_source/pages/index.vue
@@ -512,7 +512,7 @@ export default {
         return `${item[0]}=${item[1]}`
       }).join("&")
       const params = _params.length > 0 ? `?${_params}` : ''
-      return `${this.apiURL}${this.format}${this.grouping}.csv${params}`
+      return `${this.apiURL}${this.breakdown}${this.grouping}.${this.format}${params}`
     }
   },
   methods: {

--- a/iati_datastore/query_builder_source/pages/index.vue
+++ b/iati_datastore/query_builder_source/pages/index.vue
@@ -607,7 +607,7 @@ export default {
         this.updateParams()
       }
     },
-    format: {
+    breakdown: {
       handler: function(newFilters) {
         this.updateParams()
       }

--- a/iati_datastore/query_builder_source/pages/index.vue
+++ b/iati_datastore/query_builder_source/pages/index.vue
@@ -243,34 +243,73 @@
           <p>These options allow you to configure the way in which your data is disaggregated, making different sorts of analysis possible.</p>
           <b-row>
             <b-col md="4">
-              <b-form-group
-                label="Choose format">
-                <b-radio-group
-                  stacked
-                  v-model="format"
-                  :options="formatOptions">
-                </b-radio-group>
-              </b-form-group>
+              <b-row>
+                <b-col>
+                  <b-form-group
+                    label="Choose format">
+                    <b-radio-group
+                      buttons
+                      button-variant="outline-secondary"
+                      v-model="format"
+                      :options="formatOptions">
+                    </b-radio-group>
+                  </b-form-group>
+                </b-col>
+              </b-row>
+              <b-row>
+                <b-col>
+                  <b-form-group
+                    label="Choose sample size">
+                    <b-radio-group
+                      stacked
+                      v-model="stream"
+                      :options="streamOptions">
+                    </b-radio-group>
+                  </b-form-group>
+                </b-col>
+              </b-row>
             </b-col>
-            <b-col md="4">
-              <b-form-group
-                label="Repeat rows">
-                <b-radio-group
-                  stacked
-                  v-model="grouping"
-                  :options="groupingOptions">
-                </b-radio-group>
-              </b-form-group>
-            </b-col>
-            <b-col md="4">
-              <b-form-group
-                label="Choose sample size">
-                <b-radio-group
-                  stacked
-                  v-model="stream"
-                  :options="streamOptions">
-                </b-radio-group>
-              </b-form-group>
+            <b-col
+              md="8"
+              :class="format!='csv' ? 'text-muted' : null">
+              <b-card
+                header="CSV Options"
+                header-tag="h4"
+                class="mb-3"
+                id="csv-options">
+                <b-row>
+                  <b-col>
+                    <b-form-group
+                      label="Choose breakdown"
+                      :disabled="format!='csv'">
+                      <b-radio-group
+                        stacked
+                        v-model="breakdown"
+                        :options="breakdownOptions"
+                        :disabled="format!='csv'">
+                      </b-radio-group>
+                    </b-form-group>
+                  </b-col>
+                  <b-col>
+                    <b-form-group
+                      label="Repeat rows"
+                      :disabled="format!='csv'">
+                      <b-radio-group
+                        stacked
+                        v-model="grouping"
+                        :options="groupingOptions"
+                        :disabled="format!='csv'">
+                      </b-radio-group>
+                    </b-form-group>
+                  </b-col>
+                </b-row>
+              </b-card>
+              <b-tooltip
+                target="csv-options"
+                ref="tooltip"
+                :disabled="format=='csv'">
+                Options only available for CSV output.
+              </b-tooltip>
             </b-col>
           </b-row>
           <hr />
@@ -351,8 +390,23 @@ export default {
         'OrganisationType': [],
         'ReportingOrg': []
       },
-      format: 'activity',
+      format: 'xml',
       formatOptions: [
+        {
+          'value': 'xml',
+          'text': 'XML'
+        },
+        {
+          'value': 'json',
+          'text': 'JSON'
+        },
+        {
+          'value': 'csv',
+          'text': 'CSV'
+        }
+      ],
+      breakdown: 'activity',
+      breakdownOptions: [
         {
           'value': 'activity',
           'text': 'One activity per row',
@@ -420,7 +474,10 @@ export default {
       if ((this.stream) && (this.stream == true)) {
         _query.stream = this.stream
       }
-      if ((this.format) && (this.format != 'activity')) {
+      if ((this.breakdown) && (this.breakdown != 'activity')) {
+        _query.breakdown = this.breakdown
+      }
+      if ((this.format) && (this.format != 'xml')) {
         _query.format = this.format
       }
       return _query
@@ -524,6 +581,8 @@ export default {
             this.grouping = this.$route.query[item]
           } else if (item == 'stream') {
             this.stream = true
+          } else if (item=='breakdown') {
+            this.breakdown = this.$route.query[item]
           } else if (item=='format') {
             this.format = this.$route.query[item]
           }


### PR DESCRIPTION
Fixes #160

Looks like this (tooltip appears when hovering over CSV options when CSV is not selected):

![image](https://user-images.githubusercontent.com/688113/104048347-5e82f980-51e3-11eb-83c5-148fed04d009.png)
