### PR TITLE
rm datastore.wsgi

### DIFF
--- a/datastore.wsgi
+++ b/datastore.wsgi
@@ -1,3 +1,0 @@
-import os
-os.environ['DATABASE_URL'] = 'postgres:///iati-datastore'
-from iatilib.wsgi import app as application


### PR DESCRIPTION
I don’t think this is being used. (I think we’re using liveserver.py instead).