### PR TITLE
Fix some issues with /api/1/error/dataset.log

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -238,17 +238,16 @@ def dataset_log():
 
 @api.route('/error/dataset.log/<dataset_id>/')
 def dataset_log_error(dataset_id):
-    error_logs = db.session.query(Log).order_by(sa.desc(Log.created_at)).\
-                        filter(Log.dataset == dataset_id)
-    errors = []
-    for log in error_logs.all():
-        error = {}
-        error['resource_url'] = log.resource
-        error['logger'] = log.logger
-        error['msg'] = log.msg
-        error['traceback'] = log.trace.split('\n') if log.trace else []
-        error['datestamp'] = log.created_at.isoformat()
-        errors.append(error)
+    error_logs = db.session.query(Log).\
+        filter(Log.dataset == dataset_id).\
+        order_by(Log.created_at.desc())
+    errors = [{
+        'resource_url': log.resource,
+        'logger': log.logger,
+        'msg': log.msg,
+        'traceback': log.trace.split('\n') if log.trace else [],
+        'datestamp': log.created_at.isoformat(),
+    } for log in error_logs]
 
     return render_template('dataset.log', errors=errors)
 

--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -233,7 +233,10 @@ def dataset_error(dataset_id):
 @api.route('/error/dataset.log')
 def dataset_log():
     logs = db.session.query(Log.dataset).distinct()
-    return render_template('datasets.log', logs=logs)
+    response = make_response(
+        render_template('datasets.log', logs=logs))
+    response.mimetype = 'text/plain'
+    return response
 
 
 @api.route('/error/dataset.log/<dataset_id>/')
@@ -249,7 +252,10 @@ def dataset_log_error(dataset_id):
         'datestamp': log.created_at.isoformat(),
     } for log in error_logs]
 
-    return render_template('dataset.log', errors=errors)
+    response = make_response(
+        render_template('dataset.log', errors=errors))
+    response.mimetype = 'text/plain'
+    return response
 
 
 class Stream(object):

--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -246,7 +246,7 @@ def dataset_log_error(dataset_id):
         error['resource_url'] = log.resource
         error['logger'] = log.logger
         error['msg'] = log.msg
-        error['traceback'] = log.trace.split('\n')
+        error['traceback'] = log.trace.split('\n') if log.trace else []
         error['datestamp'] = log.created_at.isoformat()
         errors.append(error)
 

--- a/iati_datastore/iatilib/frontend/templates/dataset.log
+++ b/iati_datastore/iatilib/frontend/templates/dataset.log
@@ -3,4 +3,3 @@
 {%- for line in error.traceback %}
 [{{ error.datestamp }}][{{ error.logger }}]: "{{line}}" {% endfor %}
 {% endfor -%}
-


### PR DESCRIPTION
https://datastore.codeforiati.org/api/1/error/dataset.log/aics-bo/
Is returning a 500 error currently, because logs are always expected to contain a traceback (which they don’t).

Also, I think these dataset.log routes should use `text/plain` mimetype.