### PR TITLE
Stream even non-streaming requests

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -303,17 +303,18 @@ class DataStoreView(MethodView):
                 render_template('error/invalid_filter.html', errors=e), 400)
         query = self.filter(valid_args)
 
+        query = query.yield_per(100)
         if self.streaming:
-            query = query.yield_per(100)
-            body = serializer(Stream(query))
+            pagination = Stream(query)
         else:
             pagination = self.paginate(
                 query,
                 valid_args.get("offset", 0),
                 valid_args.get("limit", 50),
             )
-            body = u"".join(list(serializer(pagination)))
-        return Response(body, mimetype=mimetype)
+        return Response(
+            serializer(pagination),
+            mimetype=mimetype)
 
 
 class ActivityView(DataStoreView):


### PR DESCRIPTION
This PR changes the behaviour when `stream=false`, so that the response is served as soon as it’s available.

So for example:
https://datastore.codeforiati.org/api/1/access/activity.csv?limit=1000

Without this PR, there’s a long initial delay to compute this response, and then the whole thing is served at once.

With this PR, the initial response is served as soon as it’s available, and then the remainder is served in batches. I think this ought to be less memory-intensive.