### PR TITLE
Allow full reimport, by ignoring hashes

### DIFF
--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -127,8 +127,8 @@ def fetch_resource(dataset, ignore_hashes):
 
         resource.last_status_code = 200
         resource.last_succ = last_updated
-        if not resource.document or \
-                hash(resource.document) != hash(content) or \
+        if (not resource.document) or \
+                (hash(resource.document) != hash(content)) or \
                 ignore_hashes:
             resource.document = content
             resource.last_parsed = None

--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -106,9 +106,11 @@ def fetch_dataset_metadata(dataset):
     return dataset
 
 
-def fetch_resource(dataset):
+def fetch_resource(dataset, ignore_hashes):
     '''
     Gets the resource and sets the times of last successful update based on the status code.
+    If `ignore_hashes` is set to True, `last_parsed` will be set to None and an
+    update will be triggered.
     :param resource:
     :return:
     '''
@@ -126,7 +128,8 @@ def fetch_resource(dataset):
         resource.last_status_code = 200
         resource.last_succ = last_updated
         if not resource.document or \
-                hash(resource.document) != hash(content):
+                hash(resource.document) != hash(content) or \
+                ignore_hashes:
             resource.document = content
             resource.last_parsed = None
             resource.last_parse_error = None

--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -271,11 +271,14 @@ def update_activities(dataset_name):
         db.session.commit()
 
 
-def update_dataset(dataset_name):
+def update_dataset(dataset_name, ignore_hashes):
     '''
     Takes the dataset name and determines whether or not an update is needed based on whether or not the last
     successful update detail exits, and whether or not it last updated since the contained data was updated.
+    If ignore_hashes is set to true, an update will be triggered, regardless of whether there appears
+    to be any change in the dataset hash compared with that stored in the database.
     :param dataset_name:
+    :param ignore_hashes:
     :return:
     '''
     # clear up previous job queue log errors
@@ -307,7 +310,7 @@ def update_dataset(dataset_name):
         db.session.commit()
         return
 
-    resource = fetch_resource(dataset)
+    resource = fetch_resource(dataset, ignore_hashes)
     db.session.commit()
 
     if resource.last_status_code == 200 and not resource.last_parsed:
@@ -413,9 +416,9 @@ def download_cmd():
     iatikit.download.data()
 
 
-def download_and_update():
+def download_and_update(ignore_hashes):
     iatikit.download.data()
-    update_registry()
+    update_registry(ignore_hashes)
 
 
 @manager.cli.command('fetch-dataset-list')
@@ -426,8 +429,12 @@ def fetch_dataset_list_cmd():
     fetch_dataset_list()
 
 
+@click.option('--ignore-hashes', is_flag=True,
+              help="Ignore hashes in the database, which determine whether \
+              activities should be updated or not, and update all data. \
+              This will lead to a full refresh of data.")
 @manager.cli.command('download-and-update')
-def download_and_update_cmd():
+def download_and_update_cmd(ignore_hashes):
     """
     Enqueue a download of all IATI data from
     IATI Data Dump, and then start an update.
@@ -436,21 +443,30 @@ def download_and_update_cmd():
     print("Enqueuing a download from IATI Data Dump")
     queue.enqueue(
         download_and_update,
-        result_ttl=0, job_timeout=100000)
+        args=(ignore_hashes,),
+        result_ttl=0,
+        job_timeout=100000)
 
 
-def update_registry():
+def update_registry(ignore_hashes):
+    """
+    Get all dataset metadata and update dataset data.
+    """
     queue = rq.get_queue()
     datasets = fetch_dataset_list()
     print("Enqueuing %d datasets for update" % datasets.count())
     for dataset in datasets:
-        queue.enqueue(update_dataset, args=(dataset.name,), result_ttl=0)
+        queue.enqueue(update_dataset, args=(dataset.name, ignore_hashes), result_ttl=0)
 
 
 @click.option('--dataset', 'dataset', type=str,
               help="update a single dataset")
+@click.option('--ignore-hashes', is_flag=True,
+              help="Ignore hashes in the database, which determine whether \
+              activities should be updated or not, and update all data. \
+              This will lead to a full refresh of data.")
 @manager.cli.command('update')
-def update_cmd(dataset=None):
+def update_cmd(ignore_hashes, dataset=None):
     """
     Step through downloaded datasets, adding them to the dataset table, and then adding an update command to
     the Flask job queue. See update_registry, then update_dataset for next actions.
@@ -459,7 +475,7 @@ def update_cmd(dataset=None):
 
     if dataset is not None:
         print("Enqueuing {0} for update".format(dataset))
-        queue.enqueue(update_dataset, args=(dataset,), result_ttl=0)
+        queue.enqueue(update_dataset, args=(dataset, ignore_hashes), result_ttl=0)
     else:
         print("Enqueuing a full registry update")
-        queue.enqueue(update_registry, result_ttl=0)
+        queue.enqueue(update_registry, args=(ignore_hashes,), result_ttl=0)

--- a/iati_datastore/iatilib/test/test_crawler.py
+++ b/iati_datastore/iatilib/test/test_crawler.py
@@ -129,7 +129,7 @@ class TestCrawler(AppTestCase):
         ]
         mock_open = mock.mock_open(read_data=dataset_new_metadata)
         with mock.patch('builtins.open', mock_open):
-            crawler.update_dataset('tst-new')
+            crawler.update_dataset(dataset_name='tst-new', ignore_hashes=False)
             # resource was not added
             self.assertEquals(0, len(dataset_new.resources))
             log = Log.query.filter_by(dataset="tst-new").first()
@@ -149,7 +149,7 @@ class TestCrawler(AppTestCase):
         read_data = b"test"
         mock_open = mock.mock_open(read_data=read_data)
         with mock.patch('builtins.open', mock_open):
-            resource = crawler.fetch_resource(dataset)
+            resource = crawler.fetch_resource(dataset=dataset, ignore_hashes=False)
         self.assertEquals(b"test", resource.document)
         self.assertEquals(None, resource.last_parsed)
         self.assertEquals(None, resource.last_parse_error)
@@ -171,7 +171,7 @@ class TestCrawler(AppTestCase):
         read_data = b"test"
         mock_open = mock.mock_open(read_data=read_data)
         with mock.patch('builtins.open', mock_open):
-            resource = crawler.fetch_resource(dataset)
+            resource = crawler.fetch_resource(dataset=dataset, ignore_hashes=False)
         self.assertNotEquals(None, resource.last_parsed)
 
     def test_parse_resource_succ(self):


### PR DESCRIPTION
Refs #62. Adds a command line option to allow hashes to be ignored, in order to trigger a full reimport of data.