### PR TITLE
Change how scrollination works

### DIFF
--- a/iati_datastore/iatilib/test/test_api.py
+++ b/iati_datastore/iatilib/test/test_api.py
@@ -339,11 +339,7 @@ class TestManyActivities(ClientTestCase):
             self.assertEquals(2, len(list(reader)))
 
 
-class TestPgination(ClientTestCase):
-    def test_missing_page(self):
-        resp = self.client.get('/api/1/access/activity/?offset=100')
-        self.assertEquals(404, resp.status_code)
-
+class TestPagination(ClientTestCase):
     def test_invalid_page(self):
         resp = self.client.get('/api/1/access/activity/?offset=-1')
         self.assertEquals(400, resp.status_code)


### PR DESCRIPTION
`total` is expensive, so it should only be called when it’s used.

Fixes #235, I think.