### PR TITLE
Error logs should 404 if dataset does not exist

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict
 from datetime import datetime
 import sqlalchemy as sa
 from flask import (current_app, request, Response, Blueprint,

--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -193,11 +193,14 @@ def error():
     )
 
 
-@api.route('/error/dataset/<dataset_id>/')
-def dataset_error(dataset_id):
+@api.route('/error/dataset/<dataset>/')
+def dataset_error(dataset):
+    dataset = db.session.query(Dataset).get(dataset)
+    if dataset is None:
+        abort(404)
     error_logs = db.session.query(Log).\
-            filter(Log.dataset == dataset_id).\
-            order_by(sa.desc(Log.created_at))
+        filter(Log.dataset == dataset.name).\
+        order_by(sa.desc(Log.created_at))
     errors = [{
                 'resource_url': log.resource,
                 'dataset': log.dataset,
@@ -219,10 +222,13 @@ def dataset_log():
     return response
 
 
-@api.route('/error/dataset.log/<dataset_id>/')
-def dataset_log_error(dataset_id):
+@api.route('/error/dataset.log/<dataset>/')
+def dataset_log_error(dataset):
+    dataset = db.session.query(Dataset).get(dataset)
+    if dataset is None:
+        abort(404)
     error_logs = db.session.query(Log).\
-        filter(Log.dataset == dataset_id).\
+        filter(Log.dataset == dataset.name).\
         order_by(Log.created_at.desc())
     errors = [{
         'resource_url': log.resource,

--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -95,7 +95,7 @@ def about():
 @api.route('/about/dataset/')
 def datasets():
     query = db.session.query(Dataset)\
-        .options(db.selectinload(Dataset.resources))
+        .options(db.subqueryload(Dataset.resources))
     try:
         valid_args = validators.about_dataset_args(MultiDict(request.args))
     except (validators.MultipleInvalid, validators.Invalid) as e:

--- a/iati_datastore/iatilib/test/factories.py
+++ b/iati_datastore/iatilib/test/factories.py
@@ -116,7 +116,6 @@ class DatasetFactory(TestFactory):
     class Meta:
         model = Dataset
     name = 'test_dataset'
-    resources = factory.SubFactory(ResourceFactory)
     is_open = True
 
 

--- a/iati_datastore/iatilib/test/test_api.py
+++ b/iati_datastore/iatilib/test/test_api.py
@@ -38,7 +38,7 @@ class TestAboutDatasets(ClientTestCase):
     def test_about(self):
         fac.DatasetFactory.create(
             name='tst-old',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="http://foo",
             )]
         )
@@ -51,7 +51,7 @@ class TestAboutDatasets(ClientTestCase):
     def test_about_details(self):
         fac.DatasetFactory.create(
             name='tst-old',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="http://foo",
             )]
         )
@@ -66,7 +66,7 @@ class TestAboutDatasets(ClientTestCase):
     def test_about_dataset(self):
         fac.DatasetFactory.create(
             name='tst-old',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="http://foo",
             )]
         )
@@ -109,13 +109,19 @@ class TestErrorDatasets(ClientTestCase):
 
     def test_error_log(self):
         fac.LogFactory.create()
+        fac.DatasetFactory.create(name='bad-dataset')
         resp = self.client.get('/api/1/error/dataset.log/bad-dataset/')
         self.assertEquals(200, resp.status_code)
         self.assertEquals(
             "text/plain; charset=utf-8", resp.content_type)
 
+    def test_error_log_no_dataset(self):
+        resp = self.client.get('/api/1/error/dataset.log/no-dataset/')
+        self.assertEquals(404, resp.status_code)
+
     def test_error(self):
         fac.LogFactory.create()
+        fac.DatasetFactory.create(name='bad-dataset')
         resp = self.client.get('/api/1/error/dataset/bad-dataset/')
         data = json.loads(resp.data)
         self.assertEquals(200, resp.status_code)
@@ -126,6 +132,10 @@ class TestErrorDatasets(ClientTestCase):
         self.assertEquals(
             'Dataset is broken',
             data['errors'][0]['msg'])
+
+    def test_error_no_dataset(self):
+        resp = self.client.get('/api/1/error/dataset/no-dataset/')
+        self.assertEquals(404, resp.status_code)
 
 
 class TestDeletedActivitiesView(ClientTestCase):

--- a/iati_datastore/iatilib/test/test_crawler.py
+++ b/iati_datastore/iatilib/test/test_crawler.py
@@ -76,7 +76,7 @@ class TestCrawler(AppTestCase):
     def test_update_dataset_same_url(self, iatikit_mock):
         fac.DatasetFactory.create(
             name='tst-old',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="https://old-org.nl/sites/default/files/" +
                     "IATI/activities.xml",
             )]
@@ -98,7 +98,7 @@ class TestCrawler(AppTestCase):
         iatikit_mock.return_value = registry
         dataset = fac.DatasetFactory.create(
             name='old-org-acts',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="http://foo",
             )]
         )
@@ -117,7 +117,7 @@ class TestCrawler(AppTestCase):
             document = f.read()
         dataset = fac.DatasetFactory.create(
             name='old-org-acts',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="https://old-org.nl/sites/default/files/" +
                     "IATI/activities.xml",
                 last_parsed=datetime.datetime(2000, 1, 1),
@@ -142,7 +142,7 @@ class TestCrawler(AppTestCase):
             document = f.read()
         dataset = fac.DatasetFactory.create(
             name='old-org-acts',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="https://old-org.nl/sites/default/files/" +
                     "IATI/activities.xml",
                 last_parsed=datetime.datetime(2000, 1, 1),
@@ -250,7 +250,7 @@ class TestCrawler(AppTestCase):
     def test_deleted_activities(self, iatikit_mock):
         fac.DatasetFactory.create(
             name='deleteme',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url="http://yes",
                 activities=[
                     fac.ActivityFactory.build(
@@ -291,7 +291,7 @@ class TestResourceUpdate(AppTestCase):
         # this resouce was the first to import activity "47045-ARM-202-G05-H-00"
         fac.DatasetFactory.create(
             name='tst-a',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url=u"http://res1",
                 activities=[
                     fac.ActivityFactory.build(
@@ -306,7 +306,7 @@ class TestResourceUpdate(AppTestCase):
         # activity "47045-ARM-202-G05-H-00"
         fac.DatasetFactory.create(
             name='tst-b',
-            resources=[fac.ResourceFactory.create(
+            resources=[fac.ResourceFactory.build(
                 url=u"http://res2",
                 document=open(fixture_filename("single_activity.xml")).read().encode()
             )]


### PR DESCRIPTION
Currently, these routes do not 404:
https://datastore.codeforiati.org/api/1/error/dataset/not-a-dataset/
https://datastore.codeforiati.org/api/1/error/dataset.log/not-a-dataset/

…whereas this one does:
https://datastore.codeforiati.org/api/1/about/dataset/not-a-dataset/

This PR fixes that. We first check the dataset exists before checking for logs.