### PR TITLE
Upgrade to the latest version of iatikit

### DIFF
--- a/iati_datastore/setup.py
+++ b/iati_datastore/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requirements = """
 Flask==1.1.2
 Flask-SQLAlchemy==2.4.4
-iatikit==3.0.3
+iatikit==3.1.0
 lxml==4.6.2
 python-dateutil==2.8.1
 six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # These are duplicated here so that requires.io will flag out of date dependencies
 Flask==1.1.2
 Flask-SQLAlchemy==2.4.4
-iatikit==3.0.3
+iatikit==3.1.0
 lxml==4.6.2
 python-dateutil==2.8.1
 six==1.15.0


### PR DESCRIPTION
This new version points to s3 for the IATI data zip file.