### PR TITLE
Fix deployment using npm ci

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -15,7 +15,7 @@ def virtualenv(conn):
 def deploy(conn):
     with virtualenv(conn):
         # check out latest version of repository
-        conn.run('git checkout -- .')
+        conn.run('git checkout iati_datastore/query_builder_source/package-lock.json')
         # pull latest copy of code in version control
         conn.run('git pull origin main')
         # install dependencies

--- a/fabfile.py
+++ b/fabfile.py
@@ -14,6 +14,8 @@ def virtualenv(conn):
 @task
 def deploy(conn):
     with virtualenv(conn):
+        # check out latest version of repository
+        conn.run('git checkout -- .')
         # pull latest copy of code in version control
         conn.run('git pull origin main')
         # install dependencies

--- a/iati_datastore/iatilib/console.py
+++ b/iati_datastore/iatilib/console.py
@@ -70,7 +70,7 @@ def build_query_builder(deploy_url=None):
     """Build query builder (front page)."""
     current_path = dirname(dirname(realpath(__file__)))
     cwd = join(current_path, 'query_builder_source')
-    subprocess.run(['npm', 'i'], cwd=cwd)
+    subprocess.run(['npm', 'ci'], cwd=cwd)
 
     env = {**os.environ}
     if deploy_url is not None:

--- a/iati_datastore/iatilib/test/test_console.py
+++ b/iati_datastore/iatilib/test/test_console.py
@@ -20,7 +20,7 @@ class ConsoleTestCase(AppTestCase):
 
     @mock.patch('subprocess.run')
     def test_build_query_builder(self, mock):
-        install_command = 'npm i'
+        install_command = 'npm ci'
         build_command = 'npm run generate'
         result = self.runner.invoke(console.build_query_builder)
         self.assertEquals(0, result.exit_code)


### PR DESCRIPTION
Use `npm ci` rather than `npm i` to avoid editing `package-lock.json` on deployment