### PR TITLE
Add trailing slash to routes

### DIFF
--- a/iati_datastore/query_builder_source/nuxt.config.js
+++ b/iati_datastore/query_builder_source/nuxt.config.js
@@ -2,7 +2,11 @@ const routerBase = process.env.DEPLOY_ENV === 'WITH_SUBFOLDER' ? {
   router: {
     base: '/vuejs-datastore-query-builder/'
   }
-} : {}
+} : {
+  router: {
+    trailingSlash: true
+  }
+}
 
 const axiosBase = process.env.IATI_DATASTORE_DEPLOY_URL ? {
   axios: {


### PR DESCRIPTION
Add trailing slash to routes to avoid 404ing on `/fr`