### PR TITLE
Remove git checkout from fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -14,8 +14,6 @@ def virtualenv(conn):
 @task
 def deploy(conn):
     with virtualenv(conn):
-        # check out latest version of repository
-        conn.run('git checkout iati_datastore/query_builder_source/package-lock.json')
         # pull latest copy of code in version control
         conn.run('git pull origin main')
         # install dependencies


### PR DESCRIPTION
Now that we’re using npm ci, I don’t think this is necessary anymore.
