### PR TITLE
docs: Lock to earlier version of docutils to avoid a bug

### DIFF
--- a/iati_datastore/setup.py
+++ b/iati_datastore/setup.py
@@ -22,6 +22,7 @@ Flask-Cors==3.0.9
 Flask-Migrate==2.5.3
 Click==7.1.2
 sentry-sdk[flask]==1.3.1
+docutils==0.17.1
 """
 
 tests_require = """


### PR DESCRIPTION
Update setup.py in line with requirements.txt change
made in 56df2ebcb6504f1db0842fd0ac2f34b553bbcfbc

Should have been updated at the same time!