### PR TITLE
Upgrade iatikit to v3.3.1

### DIFF
--- a/iati_datastore/setup.py
+++ b/iati_datastore/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requirements = """
 Flask==1.1.2
 Flask-SQLAlchemy==2.4.4
-iatikit==3.3.0
+iatikit==3.3.1
 lxml==4.6.2
 python-dateutil==2.8.1
 six==1.15.0

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 # These are duplicated here so that requires.io will flag out of date dependencies
 Flask==1.1.2
 Flask-SQLAlchemy==2.4.4
-iatikit==3.3.0
+iatikit==3.3.1
 lxml==4.6.2
 python-dateutil==2.8.1
 six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,14 +71,12 @@ gevent==21.12.0
     #   -r requirements.in
     #   iati-datastore
 greenlet==1.1.2
-    # via
-    #   gevent
-    #   sqlalchemy
+    # via gevent
 gunicorn==20.0.4
     # via
     #   -r requirements.in
     #   iati-datastore
-iatikit==3.3.0
+iatikit==3.3.1
     # via
     #   -r requirements.in
     #   iati-datastore

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -109,12 +109,11 @@ greenlet==1.1.2
     # via
     #   -r requirements.txt
     #   gevent
-    #   sqlalchemy
 gunicorn==20.0.4
     # via
     #   -r requirements.txt
     #   iati-datastore
-iatikit==3.3.0
+iatikit==3.3.1
     # via
     #   -r requirements.txt
     #   iati-datastore


### PR DESCRIPTION
Refs https://github.com/codeforIATI/iati-data-dump/issues/6#issuecomment-1225562386

iatikit now reads the download location from https://iati-data-dump.codeforiati.org/download, so we can more easily change it.