### PR TITLE
Cache currency conversion table for performance reasons

### DIFF
--- a/iati_datastore/iatilib/test/test_conversion.py
+++ b/iati_datastore/iatilib/test/test_conversion.py
@@ -45,14 +45,14 @@ class TestConvertCurrencyUSD(AppTestCase):
         update_exchange_rates(self.data)
 
     def test_convert_currency(self):
-        self.assertEquals(convert_currency_usd(512.87, create_date("1973-12-05"), create_currency("AFN")), 13.47)
-        self.assertEquals(convert_currency_usd(11.43, create_date("1990-09-30"), create_currency("DZD")), 1.20)
-        self.assertEquals(convert_currency_usd(2.55, create_date("1981-08-15"), create_currency("AOA")), 85232970.12)
-        self.assertEquals(convert_currency_usd(150.00, create_date("2014-07-29"), create_currency("XCD")), 55.56)
-        self.assertEquals(convert_currency_usd(72000.00, create_date("2012-01-01"), create_currency("ARS")), 16806.72)
-        self.assertEquals(convert_currency_usd(12.50, create_date("2012-01-01"), create_currency("USD")), 12.50)
-        self.assertEquals(convert_currency_usd(0.00, create_date("2005-12-05"), create_currency("AFN")), 0.00)
-        self.assertEquals(convert_currency_usd(32.49, create_date("2017-06-01"), create_currency("ZZZ")), None)
+        self.assertEquals(convert_currency_usd(512.87, create_date("1973-12-05"), create_currency("AFN"), cache_key='test-imf'), 13.47)
+        self.assertEquals(convert_currency_usd(11.43, create_date("1990-09-30"), create_currency("DZD"), cache_key='test-imf'), 1.20)
+        self.assertEquals(convert_currency_usd(2.55, create_date("1981-08-15"), create_currency("AOA"), cache_key='test-imf'), 85232970.12)
+        self.assertEquals(convert_currency_usd(150.00, create_date("2014-07-29"), create_currency("XCD"), cache_key='test-imf'), 55.56)
+        self.assertEquals(convert_currency_usd(72000.00, create_date("2012-01-01"), create_currency("ARS"), cache_key='test-imf'), 16806.72)
+        self.assertEquals(convert_currency_usd(12.50, create_date("2012-01-01"), create_currency("USD"), cache_key='test-imf'), 12.50)
+        self.assertEquals(convert_currency_usd(0.00, create_date("2005-12-05"), create_currency("AFN"), cache_key='test-imf'), 0.00)
+        self.assertEquals(convert_currency_usd(32.49, create_date("2017-06-01"), create_currency("ZZZ"), cache_key='test-imf'), None)
 
 class TestConvertCurrencyEUR(AppTestCase):
     """Test converting currencies to EUR"""
@@ -63,12 +63,12 @@ class TestConvertCurrencyEUR(AppTestCase):
         update_exchange_rates(self.data)
 
     def test_convert_currency(self):
-        self.assertEquals(convert_currency_eur(512.87, create_date("2003-12-05"), create_currency("AFN")), 8.80)
-        self.assertEquals(convert_currency_eur(111.43, create_date("2009-09-30"), create_currency("DZD")), 1.05)
-        self.assertEquals(convert_currency_eur(2000.55, create_date("2011-08-15"), create_currency("AOA")), 15.03)
-        self.assertEquals(convert_currency_eur(150.00, create_date("2014-07-29"), create_currency("XCD")), 41.52)
-        self.assertEquals(convert_currency_eur(72000.00, create_date("2012-01-01"), create_currency("ARS")), 12989.20)
-        self.assertEquals(convert_currency_eur(12.50, create_date("2012-01-01"), create_currency("EUR")), 12.50)
-        self.assertEquals(convert_currency_eur(99.12, create_date("2021-06-15"), create_currency("USD")), 81.24)
-        self.assertEquals(convert_currency_eur(0.00, create_date("2005-12-05"), create_currency("AFN")), 0.00)
-        self.assertEquals(convert_currency_eur(32.49, create_date("2017-06-01"), create_currency("ZZZ")), None)
+        self.assertEquals(convert_currency_eur(512.87, create_date("2003-12-05"), create_currency("AFN"), cache_key='test-imf'), 8.80)
+        self.assertEquals(convert_currency_eur(111.43, create_date("2009-09-30"), create_currency("DZD"), cache_key='test-imf'), 1.05)
+        self.assertEquals(convert_currency_eur(2000.55, create_date("2011-08-15"), create_currency("AOA"), cache_key='test-imf'), 15.03)
+        self.assertEquals(convert_currency_eur(150.00, create_date("2014-07-29"), create_currency("XCD"), cache_key='test-imf'), 41.52)
+        self.assertEquals(convert_currency_eur(72000.00, create_date("2012-01-01"), create_currency("ARS"), cache_key='test-imf'), 12989.20)
+        self.assertEquals(convert_currency_eur(12.50, create_date("2012-01-01"), create_currency("EUR"), cache_key='test-imf'), 12.50)
+        self.assertEquals(convert_currency_eur(99.12, create_date("2021-06-15"), create_currency("USD"), cache_key='test-imf'), 81.24)
+        self.assertEquals(convert_currency_eur(0.00, create_date("2005-12-05"), create_currency("AFN"), cache_key='test-imf'), 0.00)
+        self.assertEquals(convert_currency_eur(32.49, create_date("2017-06-01"), create_currency("ZZZ"), cache_key='test-imf'), None)


### PR DESCRIPTION
Includes cache key with date added, both to make tests work (using different key as data is different) and so cache expires after 24 hours