### PR TITLE
Remove Deploying from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
   deploy:
     name: Deploy
     needs: test
-    if: github.ref == 'refs/heads/main'
+    # Continous Deployment has been stopped https://github.com/codeforIATI/iati-datastore/pull/407
+    if: false
+    #if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I'm going to have to upgrade our hosting to running in docker containers, so that we can keep running on the version of Python we need while allowing us to upgrade Ubuntu. Under these conditions and considering recent usage, keeping the continuous deployment going is too much work. 